### PR TITLE
Fix download demos script to use HTTPS clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsup-node lib/index.ts --format esm --dts",
     "download-references": "bun run scripts/download-references.ts",
-    "download-demos": "git clone --depth 1 --filter=blob:none --sparse git@gitlab.com:kicad/code/kicad.git kicad-demos && cd kicad-demos && git sparse-checkout set demos",
+    "download-demos": "git clone --depth 1 --filter=blob:none --sparse https://gitlab.com/kicad/code/kicad.git kicad-demos && cd kicad-demos && git sparse-checkout set demos",
     "typecheck": "bunx tsc --noEmit",
     "format": "biome format --write .",
     "format:check": "biome format ."


### PR DESCRIPTION
## Summary
- switch the download-demos script to clone the KiCad repository over HTTPS to avoid SSH host key failures on CI

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68dc6b939dd4832e9d89ba0c6308e481