### PR TITLE
Add npm badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `kicadts` is a TypeScript-first toolkit for reading, editing, and generating KiCad S-expression documents. Every KiCad token is modeled as a class, so you can compose schematics, boards, and footprints entirely in TypeScript and emit KiCad-compatible files with deterministic formatting.
 
+[![npm version](https://img.shields.io/npm/v/kicadts.svg)](https://www.npmjs.com/package/kicadts)
+
 ## Local Setup
 
 This repository uses [Bun](https://bun.sh) for scripts and testing.


### PR DESCRIPTION
## Summary
- add an npm version badge to the project README so readers can quickly navigate to the published package

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68dc70e00528832e97a7629f40f4999b