### PR TITLE
Parse solid fills for graphics

### DIFF
--- a/lib/sexpr/classes/FpCircle.ts
+++ b/lib/sexpr/classes/FpCircle.ts
@@ -323,7 +323,7 @@ export class FpCircleFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): FpCircleFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new FpCircleFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
+    return new FpCircleFill(/^(yes|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/FpCircle.ts
+++ b/lib/sexpr/classes/FpCircle.ts
@@ -323,7 +323,7 @@ export class FpCircleFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): FpCircleFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new FpCircleFill(state === "yes")
+    return new FpCircleFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/FpRect.ts
+++ b/lib/sexpr/classes/FpRect.ts
@@ -323,7 +323,7 @@ export class FpRectFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): FpRectFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new FpRectFill(state === "yes")
+    return new FpRectFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/FpRect.ts
+++ b/lib/sexpr/classes/FpRect.ts
@@ -323,7 +323,7 @@ export class FpRectFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): FpRectFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new FpRectFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
+    return new FpRectFill(/^(yes|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/GrPoly.ts
+++ b/lib/sexpr/classes/GrPoly.ts
@@ -25,7 +25,7 @@ export class GrPolyFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): GrPolyFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new GrPolyFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
+    return new GrPolyFill(/^(yes|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/GrPoly.ts
+++ b/lib/sexpr/classes/GrPoly.ts
@@ -25,7 +25,7 @@ export class GrPolyFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): GrPolyFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new GrPolyFill(state === "yes")
+    return new GrPolyFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/GrRect.ts
+++ b/lib/sexpr/classes/GrRect.ts
@@ -402,7 +402,7 @@ export class GrRectFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): GrRectFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new GrRectFill(state === "yes")
+    return new GrRectFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/GrRect.ts
+++ b/lib/sexpr/classes/GrRect.ts
@@ -402,7 +402,7 @@ export class GrRectFill extends SxClass {
     primitiveSexprs: PrimitiveSExpr[],
   ): GrRectFill {
     const state = toStringValue(primitiveSexprs[0])
-    return new GrRectFill(/^(yes|true|1|solid)$/iu.test(state ?? ""))
+    return new GrRectFill(/^(yes|solid)$/iu.test(state ?? ""))
   }
 
   override getString(): string {

--- a/lib/sexpr/classes/PadPrimitives.ts
+++ b/lib/sexpr/classes/PadPrimitives.ts
@@ -278,7 +278,7 @@ class PadPrimitiveFill extends SxPrimitiveBoolean {
   // class cannot also register under parentToken="gr_poly" without overriding
   // the board-level parser. PadPrimitiveGrPoly normalizes parsed fill tokens
   // into PadPrimitiveFill instances itself.
-  static override parentToken = "gr_poly"
+  static override parentToken = "pad_primitive_gr_poly"
   override token = "fill"
 
   constructor(options: { value?: boolean } = {}) {

--- a/lib/sexpr/classes/PadPrimitives.ts
+++ b/lib/sexpr/classes/PadPrimitives.ts
@@ -274,7 +274,11 @@ SxClass.register(PadPrimitiveGrPoly)
 
 class PadPrimitiveFill extends SxPrimitiveBoolean {
   static override token = "fill"
-  static override parentToken = "gr_poly"
+  // Pad primitive gr_poly shares the same token as board gr_poly, so its fill
+  // class cannot also register under parentToken="gr_poly" without overriding
+  // the board-level parser. PadPrimitiveGrPoly normalizes parsed fill tokens
+  // into PadPrimitiveFill instances itself.
+  static override parentToken = "pad_primitive_gr_poly"
   override token = "fill"
 
   constructor(options: { value?: boolean } = {}) {

--- a/lib/sexpr/classes/PadPrimitives.ts
+++ b/lib/sexpr/classes/PadPrimitives.ts
@@ -278,7 +278,7 @@ class PadPrimitiveFill extends SxPrimitiveBoolean {
   // class cannot also register under parentToken="gr_poly" without overriding
   // the board-level parser. PadPrimitiveGrPoly normalizes parsed fill tokens
   // into PadPrimitiveFill instances itself.
-  static override parentToken = "pad_primitive_gr_poly"
+  static override parentToken = "gr_poly"
   override token = "fill"
 
   constructor(options: { value?: boolean } = {}) {

--- a/tests/sexpr/classes/FpCircle.test.ts
+++ b/tests/sexpr/classes/FpCircle.test.ts
@@ -37,3 +37,17 @@ test("FpCircle", () => {
     )"
   `)
 })
+
+test("FpCircle parses fill solid as filled", () => {
+  const [circle] = SxClass.parse(`
+    (fp_circle
+      (center 1 1)
+      (end 2 1)
+      (layer F.SilkS)
+      (stroke (width 0.1) (type solid))
+      (fill solid)
+    )
+  `)
+
+  expect((circle as FpCircle).fill).toBe(true)
+})

--- a/tests/sexpr/classes/FpRect.test.ts
+++ b/tests/sexpr/classes/FpRect.test.ts
@@ -38,3 +38,17 @@ test("FpRect", () => {
     )"
   `)
 })
+
+test("FpRect parses fill solid as filled", () => {
+  const [rect] = SxClass.parse(`
+    (fp_rect
+      (start 0 0)
+      (end 5 5)
+      (layer F.SilkS)
+      (stroke (width 0.2) (type solid))
+      (fill solid)
+    )
+  `)
+
+  expect((rect as FpRect).fill).toBe(true)
+})

--- a/tests/sexpr/classes/GrPoly.test.ts
+++ b/tests/sexpr/classes/GrPoly.test.ts
@@ -77,6 +77,24 @@ test("GrPoly - net id", () => {
   expect(grPoly.getString()).toContain("(net 17)")
 })
 
+test("GrPoly parses fill solid as filled", () => {
+  const [poly] = SxClass.parse(`
+    (gr_poly
+        (pts
+            (xy 0 0) (xy 10 0) (xy 10 10)
+        )
+        (stroke
+            (width 0)
+            (type default)
+        )
+        (fill solid)
+        (layer "B.SilkS")
+    )
+  `)
+
+  expect((poly as GrPoly).fill).toBe(true)
+})
+
 test("GrPoly - constructor", () => {
   const grPoly = new GrPoly({
     points: [

--- a/tests/sexpr/classes/GrRect.test.ts
+++ b/tests/sexpr/classes/GrRect.test.ts
@@ -76,3 +76,20 @@ test("GrRect - getString output", () => {
   expect(output).toContain("(layer Edge.Cuts)")
   expect(output).toContain("5b95af0e-1f3a-402d-b822-c10a6e4a88c8")
 })
+
+test("GrRect parses fill solid as filled", () => {
+  const [rect] = SxClass.parse(`
+    (gr_rect
+        (start 0 -55)
+        (end 90 0)
+        (stroke
+            (width 0.05)
+            (type default)
+        )
+        (fill solid)
+        (layer "B.SilkS")
+    )
+  `)
+
+  expect((rect as GrRect).fill).toBe(true)
+})


### PR DESCRIPTION
## Summary
- parse `fill solid` as a filled shape for `fp_rect`, `fp_circle`, `gr_rect`, and board `gr_poly`
- add focused regressions covering those parser paths
- prevent pad-primitive `gr_poly` fill registration from overriding the board-level `gr_poly` fill parser

## Why
KiCad emits `fill solid` for filled graphic shapes, but these classes only treated `fill yes` as truthy. That caused filled graphics to be parsed as unfilled.

There was also a registry collision between board `gr_poly` fill parsing and pad-primitive `gr_poly` fill parsing, which meant the board parser could still resolve through the wrong fill class.

## Impact
Filled KiCad graphics now preserve their fill state when parsed, including silkscreen artwork that relies on `fill solid`.

## Validation
- `bun test tests/sexpr/classes/FpRect.test.ts tests/sexpr/classes/FpCircle.test.ts tests/sexpr/classes/GrRect.test.ts tests/sexpr/classes/GrPoly.test.ts tests/sexpr/classes/Footprint.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
