### PR TITLE
Fix kicad_sch root arc parsing with registered SchematicArc support and regression coverage

### DIFF
--- a/lib/sexpr/classes/KicadSch.ts
+++ b/lib/sexpr/classes/KicadSch.ts
@@ -20,6 +20,7 @@ import { Wire } from "./Wire"
 import { Junction } from "./Junction"
 import { NoConnect } from "./NoConnect"
 import { Polyline } from "./Polyline"
+import { SchematicArc } from "./SchematicArc"
 import { SchematicRectangle } from "./SchematicRectangle"
 import { SchematicTextBox } from "./SchematicTextBox"
 
@@ -46,6 +47,7 @@ const MULTI_CHILD_TOKENS = new Set([
   "wire",
   "no_connect",
   "sheet_instances",
+  "arc",
   "polyline",
   "rectangle",
   "text_box",
@@ -76,6 +78,7 @@ export interface KicadSchConstructorParams {
   wires?: Wire[]
   junctions?: Junction[]
   noConnects?: NoConnect[]
+  arcs?: SchematicArc[]
   polylines?: Polyline[]
   rectangles?: SchematicRectangle[]
   textBoxes?: SchematicTextBox[]
@@ -104,6 +107,7 @@ export class KicadSch extends SxClass {
   private _wires: Wire[] = []
   private _junctions: Junction[] = []
   private _noConnects: NoConnect[] = []
+  private _arcs: SchematicArc[] = []
   private _polylines: Polyline[] = []
   private _rectangles: SchematicRectangle[] = []
   private _textBoxes: SchematicTextBox[] = []
@@ -193,6 +197,10 @@ export class KicadSch extends SxClass {
       this.noConnects = params.noConnects
     }
 
+    if (params.arcs !== undefined) {
+      this.arcs = params.arcs
+    }
+
     if (params.polylines !== undefined) {
       this.polylines = params.polylines
     }
@@ -270,6 +278,7 @@ export class KicadSch extends SxClass {
       junctions: (arrayPropertyMap.junction as Junction[]) ?? [],
       wires: (arrayPropertyMap.wire as Wire[]) ?? [],
       noConnects: (arrayPropertyMap.no_connect as NoConnect[]) ?? [],
+      arcs: (arrayPropertyMap.arc as SchematicArc[]) ?? [],
       polylines: (arrayPropertyMap.polyline as Polyline[]) ?? [],
       rectangles: (arrayPropertyMap.rectangle as SchematicRectangle[]) ?? [],
       textBoxes: (arrayPropertyMap.text_box as SchematicTextBox[]) ?? [],
@@ -439,6 +448,14 @@ export class KicadSch extends SxClass {
     this._noConnects = [...value]
   }
 
+  get arcs(): SchematicArc[] {
+    return [...this._arcs]
+  }
+
+  set arcs(value: SchematicArc[]) {
+    this._arcs = [...value]
+  }
+
   get polylines(): Polyline[] {
     return [...this._polylines]
   }
@@ -484,6 +501,7 @@ export class KicadSch extends SxClass {
     children.push(...this._junctions)
     children.push(...this._wires)
     children.push(...this._noConnects)
+    children.push(...this._arcs)
     children.push(...this._polylines)
     children.push(...this._rectangles)
     children.push(...this._textBoxes)

--- a/lib/sexpr/classes/SchematicArc.ts
+++ b/lib/sexpr/classes/SchematicArc.ts
@@ -1,0 +1,216 @@
+import { SxClass } from "../base-classes/SxClass"
+import type { PrimitiveSExpr } from "../parseToPrimitiveSExpr"
+import { Stroke } from "./Stroke"
+import {
+  SymbolArcEnd,
+  SymbolArcFill,
+  SymbolArcMid,
+  SymbolArcStart,
+} from "./Symbol"
+import { Uuid } from "./Uuid"
+
+const SUPPORTED_TOKENS = new Set([
+  "start",
+  "mid",
+  "end",
+  "stroke",
+  "fill",
+  "uuid",
+  "locked",
+])
+
+export interface SchematicArcPoint {
+  x: number
+  y: number
+}
+
+export interface SchematicArcConstructorParams {
+  start?: SymbolArcStart | SchematicArcPoint
+  mid?: SymbolArcMid | SchematicArcPoint
+  end?: SymbolArcEnd | SchematicArcPoint
+  stroke?: Stroke
+  fill?: SymbolArcFill
+  uuid?: string | Uuid
+  locked?: boolean
+}
+
+export class SchematicArcLocked extends SxClass {
+  static override token = "locked"
+  static override parentToken = "arc"
+  override token = "locked"
+
+  value: boolean
+
+  constructor(value: boolean) {
+    super()
+    this.value = value
+  }
+
+  static override fromSexprPrimitives(
+    primitiveSexprs: PrimitiveSExpr[],
+  ): SchematicArcLocked {
+    const [valuePrimitive] = primitiveSexprs
+    if (typeof valuePrimitive !== "boolean") {
+      throw new Error("locked expects a boolean value")
+    }
+    return new SchematicArcLocked(valuePrimitive)
+  }
+
+  override getChildren(): SxClass[] {
+    return []
+  }
+
+  override getString(): string {
+    return `(locked ${this.value})`
+  }
+}
+SxClass.register(SchematicArcLocked)
+
+export class SchematicArc extends SxClass {
+  static override token = "arc"
+  static override parentToken = "kicad_sch"
+  override token = "arc"
+
+  private _sxStart?: SymbolArcStart
+  private _sxMid?: SymbolArcMid
+  private _sxEnd?: SymbolArcEnd
+  private _sxStroke?: Stroke
+  private _sxFill?: SymbolArcFill
+  private _sxUuid?: Uuid
+  private _sxLocked?: SchematicArcLocked
+
+  constructor(params: SchematicArcConstructorParams = {}) {
+    super()
+    if (params.start !== undefined) this.start = params.start
+    if (params.mid !== undefined) this.mid = params.mid
+    if (params.end !== undefined) this.end = params.end
+    if (params.stroke !== undefined) this.stroke = params.stroke
+    if (params.fill !== undefined) this.fill = params.fill
+    if (params.uuid !== undefined) this.uuid = params.uuid
+    if (params.locked !== undefined) this.locked = params.locked
+  }
+
+  static override fromSexprPrimitives(
+    primitiveSexprs: PrimitiveSExpr[],
+  ): SchematicArc {
+    const arc = new SchematicArc()
+    const { propertyMap, arrayPropertyMap } =
+      SxClass.parsePrimitivesToClassProperties(primitiveSexprs, this.token)
+
+    for (const [token, entries] of Object.entries(arrayPropertyMap)) {
+      if (!SUPPORTED_TOKENS.has(token)) {
+        throw new Error(`arc encountered unsupported child token "${token}"`)
+      }
+      if (entries.length > 1) {
+        throw new Error(`arc does not support repeated child token "${token}"`)
+      }
+    }
+
+    const unsupportedTokens = Object.keys(propertyMap).filter(
+      (token) => !SUPPORTED_TOKENS.has(token),
+    )
+    if (unsupportedTokens.length > 0) {
+      throw new Error(
+        `Unsupported child tokens inside arc expression: ${unsupportedTokens.join(", ")}`,
+      )
+    }
+
+    arc._sxStart = propertyMap.start as SymbolArcStart | undefined
+    arc._sxMid = propertyMap.mid as SymbolArcMid | undefined
+    arc._sxEnd = propertyMap.end as SymbolArcEnd | undefined
+    arc._sxStroke = propertyMap.stroke as Stroke | undefined
+    arc._sxFill = propertyMap.fill as SymbolArcFill | undefined
+    arc._sxUuid = propertyMap.uuid as Uuid | undefined
+    arc._sxLocked = propertyMap.locked as SchematicArcLocked | undefined
+
+    return arc
+  }
+
+  get start(): SymbolArcStart | undefined {
+    return this._sxStart
+  }
+
+  set start(value: SymbolArcStart | SchematicArcPoint | undefined) {
+    if (value === undefined) {
+      this._sxStart = undefined
+      return
+    }
+    this._sxStart =
+      value instanceof SymbolArcStart ? value : new SymbolArcStart(value.x, value.y)
+  }
+
+  get mid(): SymbolArcMid | undefined {
+    return this._sxMid
+  }
+
+  set mid(value: SymbolArcMid | SchematicArcPoint | undefined) {
+    if (value === undefined) {
+      this._sxMid = undefined
+      return
+    }
+    this._sxMid =
+      value instanceof SymbolArcMid ? value : new SymbolArcMid(value.x, value.y)
+  }
+
+  get end(): SymbolArcEnd | undefined {
+    return this._sxEnd
+  }
+
+  set end(value: SymbolArcEnd | SchematicArcPoint | undefined) {
+    if (value === undefined) {
+      this._sxEnd = undefined
+      return
+    }
+    this._sxEnd =
+      value instanceof SymbolArcEnd ? value : new SymbolArcEnd(value.x, value.y)
+  }
+
+  get stroke(): Stroke | undefined {
+    return this._sxStroke
+  }
+
+  set stroke(value: Stroke | undefined) {
+    this._sxStroke = value
+  }
+
+  get fill(): SymbolArcFill | undefined {
+    return this._sxFill
+  }
+
+  set fill(value: SymbolArcFill | undefined) {
+    this._sxFill = value
+  }
+
+  get uuid(): Uuid | undefined {
+    return this._sxUuid
+  }
+
+  set uuid(value: Uuid | string | undefined) {
+    if (value === undefined) {
+      this._sxUuid = undefined
+      return
+    }
+    this._sxUuid = value instanceof Uuid ? value : new Uuid(value)
+  }
+
+  get locked(): boolean {
+    return this._sxLocked?.value ?? false
+  }
+
+  set locked(value: boolean) {
+    this._sxLocked = value ? new SchematicArcLocked(true) : undefined
+  }
+
+  override getChildren(): SxClass[] {
+    const children: SxClass[] = []
+    if (this._sxStart) children.push(this._sxStart)
+    if (this._sxMid) children.push(this._sxMid)
+    if (this._sxEnd) children.push(this._sxEnd)
+    if (this._sxStroke) children.push(this._sxStroke)
+    if (this._sxFill) children.push(this._sxFill)
+    if (this._sxUuid) children.push(this._sxUuid)
+    if (this._sxLocked) children.push(this._sxLocked)
+    return children
+  }
+}
+SxClass.register(SchematicArc)

--- a/lib/sexpr/classes/SchematicArc.ts
+++ b/lib/sexpr/classes/SchematicArc.ts
@@ -136,7 +136,9 @@ export class SchematicArc extends SxClass {
       return
     }
     this._sxStart =
-      value instanceof SymbolArcStart ? value : new SymbolArcStart(value.x, value.y)
+      value instanceof SymbolArcStart
+        ? value
+        : new SymbolArcStart(value.x, value.y)
   }
 
   get mid(): SymbolArcMid | undefined {

--- a/lib/sexpr/index.ts
+++ b/lib/sexpr/index.ts
@@ -29,6 +29,7 @@ export * from "./classes/Wire"
 export * from "./classes/Bus"
 export * from "./classes/Junction"
 export * from "./classes/NoConnect"
+export * from "./classes/SchematicArc"
 export * from "./classes/Polyline" // Exports Polyline, SchematicPolyline, SymbolPolyline
 export * from "./classes/BusEntry"
 export * from "./classes/Label"

--- a/tests/sexpr/classes/KicadSch.test.ts
+++ b/tests/sexpr/classes/KicadSch.test.ts
@@ -2,6 +2,7 @@ import {
   KicadSch,
   Paper,
   Property,
+  SchematicArc,
   SchematicRectangle,
   SchematicSymbol,
   SchematicTextBox,
@@ -129,6 +130,32 @@ test("KicadSch parses root rectangles and text boxes", () => {
   expect(schematic.textBoxes).toHaveLength(1)
   expect(schematic.textBoxes[0]).toBeInstanceOf(SchematicTextBox)
   expect(schematic.getString()).toContain('(text_box "75"')
+})
+
+test("KicadSch parses root arcs", () => {
+  const [parsed] = SxClass.parse(`
+    (kicad_sch
+      (version 20240101)
+      (generator eeschema)
+      (uuid 01234567-89ab-cdef-0123-456789abcdef)
+      (paper A4)
+      (arc
+        (start 163.5 112.5)
+        (mid 148.5 97.5)
+        (end 133.5 112.5)
+        (stroke (width 0.75) (type default))
+        (uuid 040e42d7-787e-4aba-984f-3ca88a39a07a)
+      )
+    )
+  `)
+
+  expect(parsed).toBeInstanceOf(KicadSch)
+  const schematic = parsed as KicadSch
+  expect(schematic.arcs).toHaveLength(1)
+  expect(schematic.arcs[0]).toBeInstanceOf(SchematicArc)
+  expect(schematic.arcs[0]?.start?.x).toBe(163.5)
+  expect(schematic.arcs[0]?.mid?.y).toBe(97.5)
+  expect(schematic.getString()).toContain("\n  (arc\n")
 })
 
 test("KicadSch parse with lib_symbols, instances and sheet_instances", () => {


### PR DESCRIPTION
## Summary

This PR adds missing support for root-level `arc` nodes in `kicad_sch` files.

Previously, schematics containing top-level arcs could fail to parse because `arc` was not wired into the root `kicad_sch` child registry. This change introduces a dedicated `SchematicArc` S-expression class, registers it under `kicad_sch`, exposes it through the public `sexpr` index, and stores parsed arcs on `KicadSch` with deterministic serialization support.

## Reason 

[repro](https://github.com/tscircuit/circuit-json-to-kicad/pull/340)

This pr aims to fix this upstream 
<img width="1248" height="936" alt="image" src="https://github.com/user-attachments/assets/d3f46f26-dbc8-497b-bc4e-1b173ad5062d" />

	
## What changed

- Added a new `SchematicArc` class following the newer parser pattern
- Registered `arc` as a supported multi-child token under `kicad_sch`
- Added `arcs` support to `KicadSch` construction, parsing, getters/setters, and `getChildren()`
- Exported `SchematicArc` from the public `lib/sexpr` entrypoint
- Added a regression test that reproduces a real top-level schematic arc parse case and verifies round-trip output

## Why this matters

This is a core parser and data-modeling fix for KiCad schematic compatibility.

KiCad schematics can legally contain root-level `arc` elements, so missing support here creates avoidable parse failures and incomplete S-expression coverage. The new regression test makes sure this specific gap stays fixed and helps move the library closer to full KiCad schematic spec coverage.

## Validation

- `bun test tests/sexpr/classes/KicadSch.test.ts`
