### PR TITLE
feat: add ordered child support to SxClass

### DIFF
--- a/lib/sexpr/base-classes/SxClass.ts
+++ b/lib/sexpr/base-classes/SxClass.ts
@@ -1,6 +1,6 @@
 import {
-  parseToPrimitiveSExpr,
   type PrimitiveSExpr,
+  parseToPrimitiveSExpr,
 } from "../parseToPrimitiveSExpr"
 
 const DEFAULT_PARENT_TOKEN = "__default__"
@@ -8,6 +8,7 @@ const DEFAULT_PARENT_TOKEN = "__default__"
 export abstract class SxClass {
   abstract token: string
   static token: string
+  static childPropertyOrder?: readonly string[]
 
   /**
    * Token strings are sometimes re-used (e.g. a "type" token) but the class
@@ -18,11 +19,36 @@ export abstract class SxClass {
   isSxClass = true
 
   getChildren(): SxClass[] {
+    const childPropertyOrder = (this.constructor as typeof SxClass)
+      .childPropertyOrder
+    if (childPropertyOrder) {
+      return this.getChildrenByPropertyOrder(childPropertyOrder)
+    }
+
     // By default, return any properties found in this instance that have the _sx* prefix
     return Object.keys(this)
       .filter((k) => k.startsWith("_sx"))
       .map((k) => (this as any)[k])
       .filter((v) => v && typeof v === "object" && v.isSxClass)
+  }
+
+  protected getChildrenByPropertyOrder(
+    childPropertyOrder: readonly string[],
+  ): SxClass[] {
+    const children: SxClass[] = []
+    for (const propertyName of childPropertyOrder) {
+      const value = (this as any)[propertyName]
+      if (Array.isArray(value)) {
+        children.push(
+          ...value.filter(
+            (child) => child && typeof child === "object" && child.isSxClass,
+          ),
+        )
+      } else if (value && typeof value === "object" && value.isSxClass) {
+        children.push(value)
+      }
+    }
+    return children
   }
 
   getStringIndented(): string {
@@ -78,8 +104,9 @@ export abstract class SxClass {
     return SxClass.parsePrimitiveSexpr(primitiveSexpr) as any
   }
 
-  static fromSexprPrimitives(primitiveSexprs: PrimitiveSExpr[]): SxClass {
+  static fromSexprPrimitives(_primitiveSexprs: PrimitiveSExpr[]): SxClass {
     throw new Error(
+      // biome-ignore lint/complexity/noThisInStatic: this reports the subclass that missed the override.
       `"${this.name}" class has not implemented fromSexprPrimitives`,
     )
   }

--- a/lib/sexpr/classes/Bus.ts
+++ b/lib/sexpr/classes/Bus.ts
@@ -1,7 +1,7 @@
 import { SxClass } from "../base-classes/SxClass"
 import type { PrimitiveSExpr } from "../parseToPrimitiveSExpr"
-import { Pts } from "./Pts"
-import { Stroke } from "./Stroke"
+import type { Pts } from "./Pts"
+import type { Stroke } from "./Stroke"
 import { Uuid } from "./Uuid"
 
 const SUPPORTED_TOKENS = new Set(["pts", "stroke", "uuid"])
@@ -15,6 +15,7 @@ export interface BusConstructorParams {
 export class Bus extends SxClass {
   static override token = "bus"
   static override parentToken = "kicad_sch"
+  static override childPropertyOrder = ["_sxPts", "_sxStroke", "_sxUuid"]
   override token = "bus"
 
   private _sxPts?: Pts
@@ -41,7 +42,7 @@ export class Bus extends SxClass {
     const bus = new Bus()
 
     const { propertyMap, arrayPropertyMap } =
-      SxClass.parsePrimitivesToClassProperties(primitiveSexprs, this.token)
+      SxClass.parsePrimitivesToClassProperties(primitiveSexprs, Bus.token)
 
     if (Object.keys(arrayPropertyMap).length > 0) {
       const tokens = Object.keys(arrayPropertyMap).join(", ")
@@ -90,14 +91,6 @@ export class Bus extends SxClass {
       return
     }
     this._sxUuid = value instanceof Uuid ? value : new Uuid(value)
-  }
-
-  override getChildren(): SxClass[] {
-    const children: SxClass[] = []
-    if (this._sxPts) children.push(this._sxPts)
-    if (this._sxStroke) children.push(this._sxStroke)
-    if (this._sxUuid) children.push(this._sxUuid)
-    return children
   }
 }
 SxClass.register(Bus)

--- a/tests/sexpr/base-classes/sx-class.test.ts
+++ b/tests/sexpr/base-classes/sx-class.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { SxClass } from "lib/sexpr"
+
+class TestChild extends SxClass {
+  static override token = "test_child"
+  override token: string
+
+  constructor(token: string) {
+    super()
+    this.token = token
+  }
+}
+
+class OrderedParent extends SxClass {
+  static override token = "ordered_parent"
+  static override childPropertyOrder = ["_sxSecond", "_children", "_sxFirst"]
+  override token = "ordered_parent"
+
+  _sxFirst = new TestChild("first")
+  _children = [new TestChild("middle_a"), new TestChild("middle_b")]
+  _sxSecond = new TestChild("second")
+}
+
+test("childPropertyOrder returns children in declared order", () => {
+  const parent = new OrderedParent()
+
+  expect(parent.getChildren().map((child) => child.token)).toEqual([
+    "second",
+    "middle_a",
+    "middle_b",
+    "first",
+  ])
+})


### PR DESCRIPTION
Fixes #3

## Summary
- Add `SxClass.childPropertyOrder` so ordered S-expression classes can declare child property order once.
- Support ordered arrays and single `SxClass` child properties in the shared base helper.
- Refactor `Bus` to use the ordered child support instead of a manual `getChildren` implementation.

## Verification
- `bun test tests\sexpr\base-classes\sx-class.test.ts tests\sexpr\classes\KicadSch.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun x biome check lib\sexpr\base-classes\SxClass.ts lib\sexpr\classes\Bus.ts tests\sexpr\base-classes\sx-class.test.ts`
- `git diff --check`

Note: full `bun test` ran 83 passing / 2 skipped tests and stopped on the existing missing optional KiCad demo fixture `kicad-demos/demos/simulation/rectifier/rectifier.kicad_sch`.