### PR TITLE
Add public accessors for KiCad PCB dimension fields

### DIFF
--- a/lib/sexpr/classes/Dimension.ts
+++ b/lib/sexpr/classes/Dimension.ts
@@ -140,5 +140,25 @@ export class Dimension extends SxClass {
   get uuid(): Uuid | undefined {
     return this._sxUuid
   }
+
+  get layer(): Layer | undefined {
+    return this._sxLayer
+  }
+
+  get pts(): Pts | undefined {
+    return this._sxPts
+  }
+
+  get height(): DimensionHeight | undefined {
+    return this._sxHeight
+  }
+
+  get style(): DimensionStyle | undefined {
+    return this._sxStyle
+  }
+
+  get grText(): GrText | undefined {
+    return this._sxGrText
+  }
 }
 SxClass.register(Dimension)

--- a/lib/sexpr/classes/DimensionStyle.ts
+++ b/lib/sexpr/classes/DimensionStyle.ts
@@ -127,5 +127,37 @@ export class DimensionStyle extends SxClass {
     if (this._sxKeepTextAligned) children.push(this._sxKeepTextAligned)
     return children
   }
+
+  get thickness(): DimensionStyleThickness | undefined {
+    return this._sxThickness
+  }
+
+  get arrowLength(): DimensionArrowLength | undefined {
+    return this._sxArrowLength
+  }
+
+  get textPositionMode(): DimensionTextPositionMode | undefined {
+    return this._sxTextPositionMode
+  }
+
+  get arrowDirection(): DimensionArrowDirection | undefined {
+    return this._sxArrowDirection
+  }
+
+  get extensionHeight(): DimensionExtensionHeight | undefined {
+    return this._sxExtensionHeight
+  }
+
+  get textFrame(): DimensionTextFrame | undefined {
+    return this._sxTextFrame
+  }
+
+  get extensionOffset(): DimensionExtensionOffset | undefined {
+    return this._sxExtensionOffset
+  }
+
+  get keepTextAligned(): DimensionKeepTextAligned | undefined {
+    return this._sxKeepTextAligned
+  }
 }
 SxClass.register(DimensionStyle)


### PR DESCRIPTION
## Summary
- add public getters for parsed `Dimension` children: `layer`, `pts`, `height`, `style`, and `grText`
- add public getters for parsed `DimensionStyle` children: `thickness`, `arrowLength`, `textPositionMode`, `arrowDirection`, `extensionHeight`, `textFrame`, `extensionOffset`, and `keepTextAligned`
- keep parsing and `getString()` behavior unchanged

### Why We Need This

- kicad-to-circuit-json needs to convert KiCad board dimension objects into pcb_note_dimension. The parser already supports dimension, but only tstamp and uuid were publicly accessible. Other useful parsed fields like pts, layer, height, gr_text, and style.arrow_length were stored privately.